### PR TITLE
fix panic: check if sealRes is nil or not before getting status from it

### DIFF
--- a/op-node/rollup/derive/engine_update.go
+++ b/op-node/rollup/derive/engine_update.go
@@ -302,7 +302,11 @@ func confirmPayloadCombined(
 		}
 	default:
 		if sealPayloadErr != nil || sealRes.PayloadStatus.Status != eth.ExecutionValid {
-			return nil, BlockInsertTemporaryErr, NewTemporaryError(fmt.Errorf("failed to seal payload, status: %s, err: %w", sealRes.PayloadStatus.Status, sealPayloadErr))
+			status := eth.ExecutionUnknown
+			if sealRes != nil {
+				status = sealRes.PayloadStatus.Status
+			}
+			return nil, BlockInsertTemporaryErr, NewTemporaryError(fmt.Errorf("failed to seal payload, status: %s, err: %w", status, sealPayloadErr))
 		}
 	}
 

--- a/op-service/eth/types.go
+++ b/op-service/eth/types.go
@@ -346,6 +346,8 @@ const (
 	ExecutionInvalidTerminalBlock ExecutePayloadStatus = "INVALID_TERMINAL_BLOCK"
 	// given payload is invalid
 	ExecutionInconsistent ExecutePayloadStatus = "INCONSISTENT"
+	// unknown
+	ExecutionUnknown ExecutePayloadStatus = "UNKNOWN"
 )
 
 type PayloadStatusV1 struct {


### PR DESCRIPTION
### Description
The service panics and cannot restart when It gets a sealPayloadErr and empty seal result (nil) from op-geth service.
